### PR TITLE
Add PR template and expand commit guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Title
+<!-- Use Conventional Commit format: type(scope): short summary -->
+<!-- Example: feat(auth): add RBAC role guards -->
+
+## What & Why
+- [ ] What changed (bullet points)
+- [ ] Why this change is needed
+- [ ] Related issue/task ID: #
+
+## Test/Verification
+- [ ] Build passes locally (`./mvnw clean package`)
+- [ ] Tests pass (`./mvnw test`)
+- [ ] Manual testing completed
+- [ ] No breaking changes (or documented below)
+
+## Screenshots (if UI)
+<!-- Add before/after screenshots for visual changes -->
+
+## Breaking Changes
+<!-- List any breaking changes or mark "None" -->
+None

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,10 +21,29 @@
 - docs(infra): add local DB instructions
 - chore(repo): update .editorconfig
 
+## Conventional Commits Quick Table
+| Type | Usage | Example |
+|------|-------|---------|
+| `feat(scope)` | New feature | feat(auth): add RBAC guards |
+| `fix(scope)` | Bug fix | fix(loans): null dueAt edge case |
+| `docs(scope)` | Documentation only | docs(infra): add troubleshooting |
+| `refactor(scope)` | Code change, no behavior change | refactor(books): extract validation |
+| `chore(scope)` | Tooling or repo hygiene | chore(infra): docker compose healthcheck tune |
+| `test(scope)` | Tests only | test(auth): add role guard unit tests |
+| `ci(scope)` | CI/pipeline changes | ci: add Maven build workflow |
+| `build(scope)` | Build config changes | build: update Spring Boot to 3.6 |
+
+### Project Examples
+- `feat(auth): add RBAC role guards`
+- `feat(books): catalog search filters`
+- `feat(loans): implement renewal logic`
+- `fix(reservations): queue position calculation`
+- `docs(readme): update verification checklist`
+- `chore(infra): tune MySQL healthcheck interval`
+
 ## Before you push
 - [ ] Pull latest main/dev
 - [ ] Rebase your branch if needed
 - [ ] Build & tests pass locally
 - [ ] Commit messages follow Conventional Commits
 - [ ] PR targets `dev` (not `main`)
-


### PR DESCRIPTION
Introduces a pull request template to standardize PR submissions. Updates CONTRIBUTING.md with a quick table and examples for Conventional Commits to clarify commit message formatting for contributors.