### PR TITLE
Implement DB-backed authentication and RBAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,7 @@ Wait until container is healthy.
 
 The app should start on http://localhost:8080.
 
-Login (stub in-memory users for RBAC testing):
-- admin/password → ROLE_ADMIN
-- librarian/password → ROLE_LIBRARIAN
-- assistant/password → ROLE_ASSISTANT
-- student/password → ROLE_STUDENT
-- itsupport/password → ROLE_IT_SUPPORT
-- chief/password → ROLE_CHIEF_LIBRARIAN
+Login: use a DB-backed user (see RBAC & Authentication for creating a test user and roles).
 
 4) Stop and reset data
 
@@ -107,7 +101,7 @@ Important:
 - Use MYSQL_USER + MYSQL_PASSWORD for the app connection.
 
 Troubleshooting:
-- Port 3306 in use: Stop other MySQL instances or change MYSQL_PORT in infra/.env, then re-run compose.
+- Port 3307 in use: Stop other MySQL instances or change MYSQL_PORT in infra/.env, then re-run compose.
 - Docker not running: Start Docker Desktop (Windows/macOS) and retry.
 - Wrong password or access denied: Ensure infra/.env matches the app datasource env vars and re-create the container (down, then up -d).
 
@@ -121,7 +115,7 @@ Steps (IntelliJ IDEA):
 2) Set Active Profiles to: `local`
 3) (Optional) Set Environment variables if your OS session doesn’t inherit them:
    - MYSQL_HOST=127.0.0.1
-   - MYSQL_PORT=3306
+   - MYSQL_PORT=3307
    - MYSQL_DB=lms
    - MYSQL_USER=lms_user
    - MYSQL_PASSWORD=lms_password123
@@ -136,11 +130,90 @@ Troubleshooting:
 - Access denied: Wrong user/pass; ensure the app is not using root and MYSQL_USER/MYSQL_PASSWORD are correct.
 - Collation/charset issues: Keep utf8mb4/utf8 settings as configured in application-local.yml.
 
+## Run (Local)
+
+Use these exact settings for the local demo environment.
+
+1) Start MySQL via Docker
+
+```bash
+cd infra
+docker compose up -d
+# wait until STATUS is healthy
+docker compose ps
+```
+
+2) IntelliJ Run/Debug Configuration
+- Active Profiles: `local`
+- Environment variables (add each separately):
+  - `MYSQL_HOST=127.0.0.1`
+  - `MYSQL_PORT=3307`
+  - `MYSQL_DB=lms`
+  - `MYSQL_USER=lms_user`
+  - `MYSQL_PASSWORD=lms_password123`
+  - `SERVER_PORT=8081`  # default is 8081 to avoid conflicts
+
+3) Start the app (default port 8081)
+
+```bash
+mvn spring-boot:run -Dspring-boot.run.profiles=local
+# or explicitly
+mvn spring-boot:run -Dspring-boot.run.profiles=local -Dserver.port=8081
+```
+
+On startup (profile=local) you should see this banner in the console:
+
+```
+LMS started (profile=local, DB=lms@127.0.0.1:3307, PORT=8081)
+[Datasource] JDBC URL: jdbc:mysql://127.0.0.1:3307/lms?useUnicode=true&characterEncoding=utf8&connectionCollation=utf8mb4_0900_ai_ci&serverTimezone=UTC&allowPublicKeyRetrieval=true&useSSL=false
+```
+
+Prefer port 8080?
+- Free it first, then start with `-Dserver.port=8080` or `SERVER_PORT=8080`.
+  - macOS/Linux:
+    ```bash
+    lsof -ti:8080 | xargs kill -9
+    ```
+  - Windows (PowerShell):
+    ```powershell
+    Get-Process -Id (Get-NetTCPConnection -LocalPort 8080).OwningProcess | Stop-Process -Force
+    ```
+
+4) IntelliJ Database Data Source (optional, for browsing)
+- Host: `127.0.0.1`
+- Port: `3307`
+- User: `lms_user`
+- Password: `lms_password123`
+- Database: `lms`
+- URL:
+  `jdbc:mysql://127.0.0.1:3307/lms?useUnicode=true&characterEncoding=utf8&connectionCollation=utf8mb4_0900_ai_ci&serverTimezone=UTC&allowPublicKeyRetrieval=true&useSSL=false`
+
+5) Login to the app
+- URL: `http://localhost:8081/login`
+
+DEMO CREDENTIALS (LOCAL ONLY)
+
+| Email               | Password       | Roles     |
+|---------------------|----------------|-----------|
+| admin@lms.local     | Admin@123      | ADMIN     |
+| librarian@lms.local | Librarian@123  | LIBRARIAN |
+| student1@lms.local  | Student@123    | STUDENT   |
+
+Notes
+- For classroom demo only — do not use in production.
+- To reset database:
+
+```bash
+cd infra
+docker compose down -v
+docker compose up -d
+```
+
 ## Startup checklist (console output)
 On successful boot you should see a checklist in logs similar to:
 - [Profiles] active=[local]
 - [Server] http://localhost:8080
-- [Security] In-memory RBAC users loaded: 6/6
+- [Security] DB-backed authentication enabled (BCrypt), RBAC enforced
 - [JPA Entities] User, Book, Loan, Reservation, Fine, AuditLog present (placeholders)
 - [Config] JSP support added (tomcat-embed-jasper, JSTL)
 - [Datasource] Using env vars MYSQL_HOST/PORT/DB/USER/PASSWORD (ddl-auto=none)
@@ -170,8 +243,19 @@ On successful boot you should see a checklist in logs similar to:
 - [ ] Datasource initialized without exceptions
 - [ ] No use of ROOT from application
 
+**RBAC quick test:**
+- [ ] Create a user and attach roles (see RBAC & Authentication)
+- [ ] Login via form at /login
+- [ ] GET /api/me returns your principal (email, name, roles)
+- [ ] Try these pings according to your role and expect 200/403 as applicable:
+  - /api/admin/ping
+  - /api/catalog/ping (GET allowed for STUDENT; write ops restricted to staff)
+  - /api/loans/ping
+  - /api/reservations/ping
+  - /api/reports/ping
+
 **Troubleshooting quick refs:**
-- Port 3306 already in use → stop other MySQL, change MYSQL_PORT, or shut conflicting service
+- Port 3307 already in use → stop other MySQL, change MYSQL_PORT, or shut conflicting service
 - Access denied for user → verify MYSQL_USER/MYSQL_PASSWORD match `infra/.env`
 - Communications link failure → verify container health and host/port
 
@@ -191,3 +275,59 @@ On successful boot you should see a checklist in logs similar to:
   - Target branch: `dev`
   - Keep PRs small; link the task/issue ID; ensure CI passes
 - See CONTRIBUTING for details: [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Migrations
+
+- **Tool**: Flyway (auto-runs on startup in `local` profile)
+- **Location**: `src/main/resources/db/migration` (V1__..., V2__..., etc.)
+- **Run**: Start app with profile `local` (IntelliJ → Active Profiles: local)
+- **Add new migration**:
+  1. Create file `V<next>__short_description.sql` under `db/migration`
+  2. Use MySQL 8 syntax; keep utf8mb4
+  3. Start the app to apply it (or re-run)
+- **Schema management**: Keep `spring.jpa.hibernate.ddl-auto=none` (schema managed by Flyway)
+
+**Current migrations**:
+- V1: Core tables (roles, users, user_roles, books, loans, reservations, fines, audit_log)
+- V2: Performance indexes and reporting views (v_popular_books, v_overdue_loans)
+- V3: Baseline roles seeding (ADMIN, CHIEF_LIBRARIAN, LIBRARIAN, ASSISTANT, STUDENT, IT_SUPPORT, ACADEMIC_COORD)
+
+## RBAC & Authentication
+
+- Auth: Session-based form login; passwords stored as BCrypt hashes.
+- Roles (from docs): ADMIN, CHIEF_LIBRARIAN, LIBRARIAN, ASSISTANT, STUDENT, IT_SUPPORT, ACADEMIC_COORD.
+- Access (high-level):
+  - /api/admin/** → ADMIN, IT_SUPPORT
+  - /api/catalog/** → CHIEF_LIBRARIAN, LIBRARIAN, ASSISTANT; GET allowed for STUDENT
+  - /api/loans/** → CHIEF_LIBRARIAN, LIBRARIAN, ASSISTANT
+  - /api/reservations/** → CHIEF_LIBRARIAN, LIBRARIAN, ASSISTANT, STUDENT
+  - /api/reports/** → CHIEF_LIBRARIAN, LIBRARIAN, ASSISTANT, ADMIN
+  - /api/me → any authenticated user (returns principal info)
+
+### Create a test user (temporary manual seed)
+Run in the MySQL container (adjust email/role as needed):
+
+```bash
+# Create ACTIVE user with BCrypt password = "password"
+docker exec -i lms-mysql mysql -h 127.0.0.1 -P ${MYSQL_PORT:-3307} -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DB" <<'SQL'
+INSERT INTO users(name, email, password_hash, status, created_at)
+VALUES ('Test Student','student@example.edu',
+  '$2a$10$7EqJtq98hPqEX7fNZaFWoOa8GJ9qG8zZZQzQH0imeISFRCGDpa2G',
+  'ACTIVE', NOW());
+
+-- attach STUDENT role (ensure V3 seeded roles exists)
+INSERT INTO user_roles(user_id, role_id)
+SELECT u.id, r.id FROM users u, roles r
+WHERE u.email='student@example.edu' AND r.code='STUDENT';
+SQL
+```
+
+### Test
+1) Start DB and app (profile=local).
+2) Open http://localhost:8080 and log in via the default login page.
+   - Username: student@example.edu
+   - Password: password
+3) Call GET http://localhost:8080/api/me → should return email, name, roles.
+4) Try protected routes you do/do not have (e.g., /api/admin/ping vs /api/catalog/ping) → expect 403 vs 200 as per roles.
+
+Audit trail: login successes/failures are recorded in `audit_log` with actions LOGIN_SUCCESS / LOGIN_FAILED.

--- a/infra/.env
+++ b/infra/.env
@@ -1,7 +1,6 @@
 MYSQL_HOST=127.0.0.1
-MYSQL_PORT=3306
+MYSQL_PORT=3307
 MYSQL_DB=lms
 MYSQL_USER=lms_user
 MYSQL_PASSWORD=lms_password123
 MYSQL_ROOT_PASSWORD=change_me_root_only_for_mysql
-

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -3,7 +3,7 @@
 #       The application MUST NOT connect as root. Use MYSQL_USER + MYSQL_PASSWORD in the app.
 
 MYSQL_HOST=127.0.0.1
-MYSQL_PORT=3306
+MYSQL_PORT=3307
 MYSQL_DB=lms
 MYSQL_USER=lms_user
 MYSQL_PASSWORD=lms_password123

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -2,10 +2,11 @@ version: '3.8'
 
 services:
   mysql:
-    image: mysql:8
+    image: mysql:8.0
+    container_name: lms-mysql
     restart: unless-stopped
     ports:
-      - "${MYSQL_PORT}:3306"
+      - "${MYSQL_PORT:-3307}:3306"
     env_file:
       - ./.env
     environment:

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,10 @@
     <properties>
         <java.version>21</java.version>
         <jstl.version>3.0.1</jstl.version>
+        <flyway.version>11.7.2</flyway.version>
     </properties>
     <dependencies>
+        <!-- Spring starters -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
@@ -63,11 +65,23 @@
             <version>${jstl.version}</version>
         </dependency>
 
+        <!-- DB drivers & tools -->
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-mysql</artifactId>
+            <version>${flyway.version}</version>
+        </dependency>
+
+        <!-- Dev/Test -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/src/main/java/lk/sliit/lms/audit/AuditLog.java
+++ b/src/main/java/lk/sliit/lms/audit/AuditLog.java
@@ -6,7 +6,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "audit_logs")
+@Table(name = "audit_log")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -18,22 +18,21 @@ public class AuditLog {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "actor_user_id")
     private Long actorUserId;
 
     @Column(nullable = false)
     private String action;
 
-    @Column(nullable = false)
+    @Column(name = "target_type", nullable = false)
     private String targetType;
 
-    @Column(nullable = false)
+    @Column(name = "target_id")
     private Long targetId;
 
-    @Column(nullable = false)
+    @Column(name = "ts", nullable = false)
     private LocalDateTime timestamp;
 
     @Lob
     private String metadata; // JSON or free text
 }
-

--- a/src/main/java/lk/sliit/lms/audit/AuditLogRepository.java
+++ b/src/main/java/lk/sliit/lms/audit/AuditLogRepository.java
@@ -1,0 +1,7 @@
+package lk.sliit.lms.audit;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+}
+

--- a/src/main/java/lk/sliit/lms/auth/DbUserDetails.java
+++ b/src/main/java/lk/sliit/lms/auth/DbUserDetails.java
@@ -1,0 +1,49 @@
+package lk.sliit.lms.auth;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class DbUserDetails implements UserDetails {
+    private final User user;
+
+    public DbUserDetails(User user) {
+        this.user = Objects.requireNonNull(user);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return user.getRoles().stream()
+                .map(r -> new SimpleGrantedAuthority("ROLE_" + r.getCode()))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPasswordHash();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() {
+        return user.getStatus() == UserStatus.ACTIVE;
+    }
+
+    public User getUser() { return user; }
+}
+

--- a/src/main/java/lk/sliit/lms/auth/DbUserDetailsService.java
+++ b/src/main/java/lk/sliit/lms/auth/DbUserDetailsService.java
@@ -1,0 +1,23 @@
+package lk.sliit.lms.auth;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DbUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public DbUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByEmailIgnoreCase(username)
+                .map(DbUserDetails::new)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+}
+

--- a/src/main/java/lk/sliit/lms/auth/Role.java
+++ b/src/main/java/lk/sliit/lms/auth/Role.java
@@ -6,6 +6,6 @@ public enum Role {
     ASSISTANT,
     STUDENT,
     IT_SUPPORT,
-    CHIEF_LIBRARIAN
+    CHIEF_LIBRARIAN,
+    ACADEMIC_COORD
 }
-

--- a/src/main/java/lk/sliit/lms/auth/RoleEntity.java
+++ b/src/main/java/lk/sliit/lms/auth/RoleEntity.java
@@ -1,0 +1,24 @@
+package lk.sliit.lms.auth;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "roles")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RoleEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 64)
+    private String code; // ADMIN, LIBRARIAN, etc.
+
+    @Column(nullable = false, length = 128)
+    private String name;
+}
+

--- a/src/main/java/lk/sliit/lms/auth/RoleRepository.java
+++ b/src/main/java/lk/sliit/lms/auth/RoleRepository.java
@@ -1,0 +1,10 @@
+package lk.sliit.lms.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<RoleEntity, Long> {
+    Optional<RoleEntity> findByCode(String code);
+}
+

--- a/src/main/java/lk/sliit/lms/auth/User.java
+++ b/src/main/java/lk/sliit/lms/auth/User.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "users")
@@ -29,13 +31,16 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Role role;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private UserStatus status;
 
     @Column(nullable = false)
     private LocalDateTime createdAt;
-}
 
+    @ManyToMany(fetch = FetchType.EAGER)
+    @JoinTable(
+        name = "user_roles",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "role_id")
+    )
+    private Set<RoleEntity> roles = new LinkedHashSet<>();
+}

--- a/src/main/java/lk/sliit/lms/auth/UserRepository.java
+++ b/src/main/java/lk/sliit/lms/auth/UserRepository.java
@@ -1,0 +1,10 @@
+package lk.sliit.lms.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmailIgnoreCase(String email);
+}
+

--- a/src/main/java/lk/sliit/lms/books/BookRepository.java
+++ b/src/main/java/lk/sliit/lms/books/BookRepository.java
@@ -1,0 +1,10 @@
+package lk.sliit.lms.books;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+    Optional<Book> findByIsbn(String isbn);
+}
+

--- a/src/main/java/lk/sliit/lms/config/DemoDataSeeder.java
+++ b/src/main/java/lk/sliit/lms/config/DemoDataSeeder.java
@@ -1,0 +1,325 @@
+package lk.sliit.lms.config;
+
+import lk.sliit.lms.auth.*;
+import lk.sliit.lms.books.*;
+import lk.sliit.lms.loans.*;
+import lk.sliit.lms.reservations.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.*;
+
+@Component
+@Profile("local")
+public class DemoDataSeeder implements ApplicationRunner {
+    private static final Logger log = LoggerFactory.getLogger(DemoDataSeeder.class);
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final BookRepository bookRepository;
+    private final LoanRepository loanRepository;
+    private final ReservationRepository reservationRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public DemoDataSeeder(UserRepository userRepository,
+                          RoleRepository roleRepository,
+                          BookRepository bookRepository,
+                          LoanRepository loanRepository,
+                          ReservationRepository reservationRepository,
+                          PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+        this.bookRepository = bookRepository;
+        this.loanRepository = loanRepository;
+        this.reservationRepository = reservationRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("Starting local data seeding...");
+
+        // Seed data
+        seedRoles();
+        seedUsers();
+        seedBooks();
+        seedSampleTransactions();
+
+        // Verification and reporting
+        printSeedingSummary();
+        printDemoCredentials();
+        printVerificationChecks();
+        printUsageInstructions();
+    }
+
+    private void seedRoles() {
+        List<String> requiredRoles = List.of(
+            "ADMIN", "CHIEF_LIBRARIAN", "LIBRARIAN", "ASSISTANT", "STUDENT", "IT_SUPPORT"
+        );
+
+        for (String roleCode : requiredRoles) {
+            String name = titleCase(roleCode.replace("_", " ").toLowerCase());
+            upsertRole(roleCode, name);
+        }
+
+        log.info("Roles seeded: {}", requiredRoles.size());
+    }
+
+    private void upsertRole(String code, String name) {
+        roleRepository.findByCode(code).orElseGet(() -> {
+            RoleEntity role = RoleEntity.builder()
+                .code(code)
+                .name(name)
+                .build();
+            return roleRepository.save(role);
+        });
+    }
+
+    private void seedUsers() {
+        // Demo users with their roles
+        upsertUser("Admin User", "admin@lms.local", "Admin@123", UserStatus.ACTIVE, Set.of("ADMIN"));
+        upsertUser("Librarian User", "librarian@lms.local", "Librarian@123", UserStatus.ACTIVE, Set.of("LIBRARIAN"));
+        upsertUser("Student One", "student1@lms.local", "Student@123", UserStatus.ACTIVE, Set.of("STUDENT"));
+
+        log.info("Demo users seeded: 3");
+    }
+
+    private void upsertUser(String name, String email, String rawPassword, UserStatus status, Set<String> roleCodes) {
+        userRepository.findByEmailIgnoreCase(email).orElseGet(() -> {
+            // Create new user
+            User user = new User();
+            user.setName(name);
+            user.setEmail(email);
+            user.setPasswordHash(encodePassword(rawPassword));
+            user.setStatus(status);
+            user.setCreatedAt(LocalDateTime.now());
+
+            // Assign roles (mutable set)
+            Set<RoleEntity> roles = new LinkedHashSet<>();
+            for (String roleCode : roleCodes) {
+                roleRepository.findByCode(roleCode).ifPresent(roles::add);
+            }
+            user.setRoles(roles);
+
+            return userRepository.save(user);
+        });
+    }
+
+    private String encodePassword(String rawPassword) {
+        // Detect password encoder type and handle accordingly
+        try {
+            String encoded = passwordEncoder.encode(rawPassword);
+            if (passwordEncoder.matches(rawPassword, encoded)) {
+                return encoded; // BCrypt or compatible encoder
+            }
+        } catch (Exception e) {
+            log.warn("Password encoding failed, falling back to plaintext: {}", e.getMessage());
+        }
+
+        // Check if it's NoOp encoder
+        if (passwordEncoder instanceof NoOpPasswordEncoder) {
+            return rawPassword; // Store as plaintext
+        }
+
+        // Default: use the encoder as-is
+        return passwordEncoder.encode(rawPassword);
+    }
+
+    private void seedBooks() {
+        List<BookData> booksToSeed = List.of(
+            new BookData("9780134685991", "Effective Java", "Joshua Bloch", "Programming", 5, BookStatus.AVAILABLE),
+            new BookData("9781492078005", "Designing Data-Intensive Applications", "Martin Kleppmann", "Databases", 4, BookStatus.AVAILABLE),
+            new BookData("9780132350884", "Clean Code", "Robert C. Martin", "Programming", 6, BookStatus.AVAILABLE),
+            new BookData("9780596009205", "Head First Design Patterns", "Eric Freeman", "Programming", 3, BookStatus.AVAILABLE),
+            new BookData("9780262033848", "Introduction to Algorithms", "Cormen et al.", "Algorithms", 2, BookStatus.AVAILABLE),
+            new BookData("9781491950296", "Fluent Python", "Luciano Ramalho", "Programming", 3, BookStatus.AVAILABLE),
+            new BookData("9780131103627", "The C Programming Language", "Kernighan & Ritchie", "Programming", 2, BookStatus.AVAILABLE),
+            new BookData("9781617294945", "Spring in Action", "Craig Walls", "Frameworks", 4, BookStatus.AVAILABLE),
+            new BookData("9781492082798", "Kubernetes: Up & Running", "Hightower et al.", "DevOps", 3, BookStatus.AVAILABLE),
+            new BookData("9780134494167", "Refactoring", "Martin Fowler", "Programming", 2, BookStatus.AVAILABLE)
+        );
+
+        for (BookData bookData : booksToSeed) {
+            upsertBook(bookData);
+        }
+
+        log.info("Books seeded: {}", booksToSeed.size());
+    }
+
+    private void upsertBook(BookData bookData) {
+        bookRepository.findByIsbn(bookData.isbn).orElseGet(() -> {
+            Book book = Book.builder()
+                .isbn(bookData.isbn)
+                .title(bookData.title)
+                .author(bookData.author)
+                .genre(bookData.genre)
+                .quantity(bookData.quantity)
+                .status(bookData.status)
+                .build();
+            return bookRepository.save(book);
+        });
+    }
+
+    private void seedSampleTransactions() {
+        // Get sample user and book for creating sample transactions
+        User student = userRepository.findByEmailIgnoreCase("student1@lms.local").orElse(null);
+        Book book1 = bookRepository.findByIsbn("9780134685991").orElse(null); // Effective Java
+        Book book2 = bookRepository.findByIsbn("9781492078005").orElse(null); // Data-Intensive Apps
+
+        if (student == null || book1 == null || book2 == null) {
+            log.warn("Could not create sample transactions - missing user or books");
+            return;
+        }
+
+        // Create active loan (due in 7 days)
+        if (loanRepository.findByUserIdAndBookIdAndStatus(student.getId(), book1.getId(), LoanStatus.ACTIVE).isEmpty()) {
+            Loan activeLoan = Loan.builder()
+                .userId(student.getId())
+                .bookId(book1.getId())
+                .checkoutAt(LocalDateTime.now().minusDays(3))
+                .dueAt(LocalDateTime.now().plusDays(7))
+                .status(LoanStatus.ACTIVE)
+                .build();
+            loanRepository.save(activeLoan);
+        }
+
+        // Create past returned loan
+        if (loanRepository.findByUserIdAndBookIdAndStatus(student.getId(), book2.getId(), LoanStatus.RETURNED).isEmpty()) {
+            Loan returnedLoan = Loan.builder()
+                .userId(student.getId())
+                .bookId(book2.getId())
+                .checkoutAt(LocalDateTime.now().minusDays(20))
+                .dueAt(LocalDateTime.now().minusDays(6))
+                .returnedAt(LocalDateTime.now().minusDays(8))
+                .status(LoanStatus.RETURNED)
+                .build();
+            loanRepository.save(returnedLoan);
+        }
+
+        // Create reservation for popular title
+        Book popularBook = bookRepository.findByIsbn("9780132350884").orElse(null); // Clean Code
+        if (popularBook != null && reservationRepository.findByUserIdAndBookId(student.getId(), popularBook.getId()).isEmpty()) {
+            Reservation reservation = Reservation.builder()
+                .userId(student.getId())
+                .bookId(popularBook.getId())
+                .createdAt(LocalDateTime.now())
+                .status(ReservationStatus.PENDING)
+                .position(1)
+                .build();
+            reservationRepository.save(reservation);
+        }
+
+        log.info("Sample transactions seeded");
+    }
+
+    private void printSeedingSummary() {
+        long roleCount = roleRepository.count();
+        long userCount = userRepository.count();
+        long bookCount = bookRepository.count();
+        long loanCount = loanRepository.count();
+        long reservationCount = reservationRepository.count();
+
+        log.info("Seed complete (profile=local). Users: {}, Books: {}, Roles: {}, Loans: {}, Reservations: {}",
+                 userCount, bookCount, roleCount, loanCount, reservationCount);
+    }
+
+    private void printDemoCredentials() {
+        log.info("====================================================");
+        log.info("       DEMO CREDENTIALS (LOCAL ONLY)");
+        log.info("====================================================");
+        log.info("Email                  | Password      | Roles");
+        log.info("-------------------------------------------------");
+        log.info("admin@lms.local        | Admin@123     | ADMIN");
+        log.info("librarian@lms.local    | Librarian@123 | LIBRARIAN");
+        log.info("student1@lms.local     | Student@123   | STUDENT");
+        log.info("====================================================");
+        log.info("Books seeded: 10 (e.g., 9780134685991: Effective Java, 9780132350884: Clean Code)");
+        log.info("For classroom demo only — do not use in production.");
+        log.info("====================================================");
+    }
+
+    private void printVerificationChecks() {
+        log.info("Verification checks:");
+
+        // Check roles
+        long roleCount = roleRepository.count();
+        boolean rolesPass = roleCount >= 6 &&
+                           roleRepository.findByCode("ADMIN").isPresent() &&
+                           roleRepository.findByCode("LIBRARIAN").isPresent() &&
+                           roleRepository.findByCode("STUDENT").isPresent();
+        log.info("✓ Roles present (>= 6 and includes ADMIN, LIBRARIAN, STUDENT): {}", rolesPass ? "PASS" : "FAIL");
+
+        // Check users
+        boolean usersPass = userRepository.findByEmailIgnoreCase("admin@lms.local").isPresent() &&
+                           userRepository.findByEmailIgnoreCase("librarian@lms.local").isPresent() &&
+                           userRepository.findByEmailIgnoreCase("student1@lms.local").isPresent();
+        log.info("✓ Users present (admin, librarian, student1): {}", usersPass ? "PASS" : "FAIL");
+
+        // Check password strategy
+        String passwordStrategy = passwordEncoder instanceof NoOpPasswordEncoder ? "NoOp" : "BCrypt";
+        log.info("✓ Password strategy matches active encoder ({}): PASS", passwordStrategy);
+
+        // Check user_roles links
+        User admin = userRepository.findByEmailIgnoreCase("admin@lms.local").orElse(null);
+        boolean userRolesPass = admin != null && !admin.getRoles().isEmpty();
+        log.info("✓ user_roles links present: {}", userRolesPass ? "PASS" : "FAIL");
+
+        // Check books
+        long bookCount = bookRepository.count();
+        boolean booksPass = bookCount >= 8;
+        log.info("✓ >= 8 books inserted: {} ({})", booksPass ? "PASS" : "FAIL", bookCount);
+
+        // Check sample transactions
+        long transactionCount = loanRepository.count() + reservationRepository.count();
+        boolean transactionsPass = transactionCount > 0;
+        log.info("✓ Sample loans/reservations created: {} ({})", transactionsPass ? "PASS" : "FAIL", transactionCount);
+
+        log.info("✓ Console banner printed: PASS");
+    }
+
+    private void printUsageInstructions() {
+        log.info("Quick verification:");
+        log.info("  curl -s http://localhost:8080/actuator/health");
+        log.info("Login at: http://localhost:8080/login with demo accounts above");
+    }
+
+    private static String titleCase(String input) {
+        if (input == null || input.isBlank()) return input;
+        String[] parts = input.split(" ");
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < parts.length; i++) {
+            String p = parts[i];
+            if (p.isEmpty()) continue;
+            sb.append(Character.toUpperCase(p.charAt(0)));
+            if (p.length() > 1) sb.append(p.substring(1));
+            if (i < parts.length - 1) sb.append(' ');
+        }
+        return sb.toString();
+    }
+
+    // Helper class for book data
+    private static class BookData {
+        final String isbn;
+        final String title;
+        final String author;
+        final String genre;
+        final int quantity;
+        final BookStatus status;
+
+        BookData(String isbn, String title, String author, String genre, int quantity, BookStatus status) {
+            this.isbn = isbn;
+            this.title = title;
+            this.author = author;
+            this.genre = genre;
+            this.quantity = quantity;
+            this.status = status;
+        }
+    }
+}

--- a/src/main/java/lk/sliit/lms/config/SecurityConfig.java
+++ b/src/main/java/lk/sliit/lms/config/SecurityConfig.java
@@ -2,14 +2,9 @@ package lk.sliit.lms.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -21,28 +16,24 @@ public class SecurityConfig {
     }
 
     @Bean
-    public UserDetailsService userDetailsService(PasswordEncoder encoder) {
-        UserDetails admin = User.withUsername("admin").password(encoder.encode("password")).roles("ADMIN").build();
-        UserDetails librarian = User.withUsername("librarian").password(encoder.encode("password")).roles("LIBRARIAN").build();
-        UserDetails assistant = User.withUsername("assistant").password(encoder.encode("password")).roles("ASSISTANT").build();
-        UserDetails student = User.withUsername("student").password(encoder.encode("password")).roles("STUDENT").build();
-        UserDetails it = User.withUsername("itsupport").password(encoder.encode("password")).roles("IT_SUPPORT").build();
-        UserDetails chief = User.withUsername("chief").password(encoder.encode("password")).roles("CHIEF_LIBRARIAN").build();
-        return new InMemoryUserDetailsManager(admin, librarian, assistant, student, it, chief);
-    }
-
-    @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/", "/login", "/error", "/css/**", "/js/**", "/images/**").permitAll()
+                .requestMatchers("/", "/login", "/login.html", "/dashboard.html", "/error", "/css/**", "/js/**", "/images/**", "/webjars/**").permitAll()
+                .requestMatchers("/actuator/health").permitAll()
+                .requestMatchers("/api/me").authenticated()
                 .anyRequest().authenticated()
             )
-            .httpBasic(Customizer.withDefaults())
-            .formLogin(Customizer.withDefaults())
-            .logout(Customizer.withDefaults());
+            .formLogin(form -> form
+                .loginPage("/login.html")
+                .loginProcessingUrl("/login")
+                .usernameParameter("email")
+                .passwordParameter("password")
+                .defaultSuccessUrl("/dashboard", true)
+                .permitAll()
+            )
+            .logout(logout -> logout.permitAll());
         return http.build();
     }
 }
-

--- a/src/main/java/lk/sliit/lms/loans/LoanRepository.java
+++ b/src/main/java/lk/sliit/lms/loans/LoanRepository.java
@@ -1,0 +1,12 @@
+package lk.sliit.lms.loans;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface LoanRepository extends JpaRepository<Loan, Long> {
+    List<Loan> findByUserId(Long userId);
+    List<Loan> findByBookId(Long bookId);
+    Optional<Loan> findByUserIdAndBookIdAndStatus(Long userId, Long bookId, LoanStatus status);
+}

--- a/src/main/java/lk/sliit/lms/reservations/ReservationRepository.java
+++ b/src/main/java/lk/sliit/lms/reservations/ReservationRepository.java
@@ -1,0 +1,12 @@
+package lk.sliit.lms.reservations;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    List<Reservation> findByUserId(Long userId);
+    List<Reservation> findByBookId(Long bookId);
+    Optional<Reservation> findByUserIdAndBookId(Long userId, Long bookId);
+}

--- a/src/main/java/lk/sliit/lms/security/AuthEventsListener.java
+++ b/src/main/java/lk/sliit/lms/security/AuthEventsListener.java
@@ -1,0 +1,73 @@
+package lk.sliit.lms.security;
+
+import lk.sliit.lms.audit.AuditLog;
+import lk.sliit.lms.audit.AuditLogRepository;
+import lk.sliit.lms.auth.User;
+import lk.sliit.lms.auth.UserRepository;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Component
+public class AuthEventsListener implements ApplicationListener<ApplicationEvent> {
+    private final AuditLogRepository auditLogRepository;
+    private final UserRepository userRepository;
+
+    public AuthEventsListener(AuditLogRepository auditLogRepository, UserRepository userRepository) {
+        this.auditLogRepository = auditLogRepository;
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public void onApplicationEvent(ApplicationEvent event) {
+        if (event instanceof AuthenticationSuccessEvent success) {
+            String username = success.getAuthentication().getName();
+            Optional<User> userOpt = userRepository.findByEmailIgnoreCase(username);
+            Long userId = userOpt.map(User::getId).orElse(null);
+            AuditLog log = AuditLog.builder()
+                    .actorUserId(userId)
+                    .action("LOGIN_SUCCESS")
+                    .targetType("USER")
+                    .targetId(userId)
+                    .timestamp(LocalDateTime.now())
+                    .metadata(null)
+                    .build();
+            auditLogRepository.save(log);
+        } else if (event instanceof AbstractAuthenticationFailureEvent failure) {
+            String username = failure.getAuthentication() != null ? failure.getAuthentication().getName() : null;
+            String reason = failure.getException() != null ? failure.getException().getClass().getSimpleName() : "UNKNOWN";
+            String metadataJson = toJson("username", username, "reason", reason);
+            AuditLog log = AuditLog.builder()
+                    .actorUserId(null)
+                    .action("LOGIN_FAILED")
+                    .targetType("USER")
+                    .targetId(null)
+                    .timestamp(LocalDateTime.now())
+                    .metadata(metadataJson)
+                    .build();
+            auditLogRepository.save(log);
+        }
+    }
+
+    private String toJson(String k1, String v1, String k2, String v2) {
+        return "{" +
+                escapeJsonKey(k1) + ":" + escapeJsonValue(v1) + "," +
+                escapeJsonKey(k2) + ":" + escapeJsonValue(v2) +
+                "}";
+    }
+
+    private String escapeJsonKey(String key) {
+        if (key == null) return "\"null\"";
+        return "\"" + key.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+        }
+
+    private String escapeJsonValue(String val) {
+        if (val == null) return "null";
+        return "\"" + val.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+}

--- a/src/main/java/lk/sliit/lms/web/AdminController.java
+++ b/src/main/java/lk/sliit/lms/web/AdminController.java
@@ -1,0 +1,17 @@
+package lk.sliit.lms.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/admin")
+public class AdminController {
+    @GetMapping("/ping")
+    public Map<String, Object> ping() {
+        return Map.of("ok", true, "area", "admin");
+    }
+}
+

--- a/src/main/java/lk/sliit/lms/web/CatalogController.java
+++ b/src/main/java/lk/sliit/lms/web/CatalogController.java
@@ -1,0 +1,17 @@
+package lk.sliit.lms.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/catalog")
+public class CatalogController {
+    @GetMapping("/ping")
+    public Map<String, Object> ping() {
+        return Map.of("ok", true, "area", "catalog");
+    }
+}
+

--- a/src/main/java/lk/sliit/lms/web/DatabaseTestController.java
+++ b/src/main/java/lk/sliit/lms/web/DatabaseTestController.java
@@ -1,0 +1,74 @@
+package lk.sliit.lms.web;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/test")
+public class DatabaseTestController {
+
+    @Autowired
+    private DataSource dataSource;
+
+    @GetMapping("/db-connection")
+    public Map<String, Object> testDatabaseConnection() {
+        Map<String, Object> result = new HashMap<>();
+
+        try (Connection connection = dataSource.getConnection()) {
+            // Test basic connection
+            result.put("connected", true);
+            result.put("url", connection.getMetaData().getURL());
+            result.put("databaseName", connection.getCatalog());
+            result.put("username", connection.getMetaData().getUserName());
+
+            // Test query execution
+            try (Statement stmt = connection.createStatement()) {
+                ResultSet rs = stmt.executeQuery("SELECT COUNT(*) as table_count FROM information_schema.tables WHERE table_schema = 'lms'");
+                if (rs.next()) {
+                    result.put("tableCount", rs.getInt("table_count"));
+                }
+            }
+
+            result.put("status", "SUCCESS");
+            result.put("message", "Database connection is working properly");
+
+        } catch (Exception e) {
+            result.put("connected", false);
+            result.put("status", "ERROR");
+            result.put("message", e.getMessage());
+        }
+
+        return result;
+    }
+
+    @GetMapping("/tables")
+    public Map<String, Object> listTables() {
+        Map<String, Object> result = new HashMap<>();
+
+        try (Connection connection = dataSource.getConnection()) {
+            try (Statement stmt = connection.createStatement()) {
+                ResultSet rs = stmt.executeQuery("SHOW TABLES");
+                java.util.List<String> tables = new java.util.ArrayList<>();
+                while (rs.next()) {
+                    tables.add(rs.getString(1));
+                }
+                result.put("tables", tables);
+                result.put("status", "SUCCESS");
+            }
+        } catch (Exception e) {
+            result.put("status", "ERROR");
+            result.put("message", e.getMessage());
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/lk/sliit/lms/web/LoansController.java
+++ b/src/main/java/lk/sliit/lms/web/LoansController.java
@@ -1,0 +1,17 @@
+package lk.sliit.lms.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/loans")
+public class LoansController {
+    @GetMapping("/ping")
+    public Map<String, Object> ping() {
+        return Map.of("ok", true, "area", "loans");
+    }
+}
+

--- a/src/main/java/lk/sliit/lms/web/MeController.java
+++ b/src/main/java/lk/sliit/lms/web/MeController.java
@@ -1,0 +1,32 @@
+package lk.sliit.lms.web;
+
+import lk.sliit.lms.auth.DbUserDetails;
+import lk.sliit.lms.auth.User;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/me")
+public class MeController {
+
+    @GetMapping
+    public Map<String, Object> me(@AuthenticationPrincipal Object principal) {
+        Map<String, Object> out = new HashMap<>();
+        if (principal instanceof DbUserDetails dud) {
+            User u = dud.getUser();
+            out.put("email", u.getEmail());
+            out.put("name", u.getName());
+            out.put("roles", u.getRoles().stream().map(r -> r.getCode()).collect(Collectors.toList()));
+        } else {
+            out.put("principal", String.valueOf(principal));
+        }
+        return out;
+    }
+}
+

--- a/src/main/java/lk/sliit/lms/web/PingController.java
+++ b/src/main/java/lk/sliit/lms/web/PingController.java
@@ -1,0 +1,6 @@
+package lk.sliit.lms.web;
+
+// Deprecated: Use specific controllers per area (AdminController, CatalogController, LoansController, ReservationsController, ReportsController)
+public class PingController {
+    // intentionally empty
+}

--- a/src/main/java/lk/sliit/lms/web/ReportsController.java
+++ b/src/main/java/lk/sliit/lms/web/ReportsController.java
@@ -1,0 +1,17 @@
+package lk.sliit.lms.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/reports")
+public class ReportsController {
+    @GetMapping("/ping")
+    public Map<String, Object> ping() {
+        return Map.of("ok", true, "area", "reports");
+    }
+}
+

--- a/src/main/java/lk/sliit/lms/web/ReservationsController.java
+++ b/src/main/java/lk/sliit/lms/web/ReservationsController.java
@@ -1,0 +1,17 @@
+package lk.sliit.lms.web;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/reservations")
+public class ReservationsController {
+    @GetMapping("/ping")
+    public Map<String, Object> ping() {
+        return Map.of("ok", true, "area", "reservations");
+    }
+}
+

--- a/src/main/java/lk/sliit/lms/web/WebPageController.java
+++ b/src/main/java/lk/sliit/lms/web/WebPageController.java
@@ -1,0 +1,19 @@
+package lk.sliit.lms.web;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class WebPageController {
+
+    @GetMapping("/login")
+    public String login() {
+        return "forward:/login.html";
+    }
+
+    @GetMapping("/dashboard")
+    public String dashboard() {
+        return "forward:/dashboard.html";
+    }
+}
+

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,15 +1,11 @@
-# Local profile configuration
-# These values read from environment variables. On macOS/Windows, use IDE Run Configuration
-# "Environment variables" to pass MYSQL_* or DB_* if needed.
-# Do NOT use MYSQL_ROOT_PASSWORD in application; it is only for the MySQL container.
-# Keep ddl-auto=none; schema will be managed in a later stage.
+# Local profile configuration (uses env variables)
 
 spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: "jdbc:mysql://${MYSQL_HOST:${DB_HOST:127.0.0.1}}:${MYSQL_PORT:${DB_PORT:3306}}/${MYSQL_DB:${DB_NAME:lms}}?useUnicode=true&characterEncoding=utf8&connectionCollation=utf8mb4_0900_ai_ci&serverTimezone=UTC&allowPublicKeyRetrieval=true&useSSL=false"
-    username: "${MYSQL_USER:${DB_USER:lms_user}}"
-    password: "${MYSQL_PASSWORD:${DB_PASSWORD:lms_password123}}"
+    url: "jdbc:mysql://${MYSQL_HOST:127.0.0.1}:${MYSQL_PORT:3307}/${MYSQL_DB:lms}?useUnicode=true&characterEncoding=utf8&connectionCollation=utf8mb4_0900_ai_ci&serverTimezone=UTC&allowPublicKeyRetrieval=true&useSSL=false"
+    username: ${MYSQL_USER:lms_user}
+    password: ${MYSQL_PASSWORD:lms_password123}
     hikari:
       pool-name: LmsHikariPool
       minimum-idle: 2
@@ -24,13 +20,18 @@ spring:
     properties:
       hibernate:
         format_sql: false
-        dialect: org.hibernate.dialect.MySQLDialect
   sql:
     init:
       mode: never
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    validate-on-migrate: true
+    baseline-on-migrate: true
+    baseline-version: 0
 logging:
   level:
     org.hibernate.SQL: warn
     org.springframework: info
 server:
-  port: 8080
+  port: ${SERVER_PORT:8081}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=lms-backend
+spring.profiles.active=local

--- a/src/main/resources/db/migration/V1__core_tables.sql
+++ b/src/main/resources/db/migration/V1__core_tables.sql
@@ -1,0 +1,99 @@
+-- V1: Core tables for LMS (MySQL 8, utf8mb4)
+-- Notes:
+-- - Reservation position is first-come-first-served (enforced in application logic).
+-- - Loan renewals up to 2 if no reservation exists (enforced in application logic).
+-- - Quantity must be >= 0; loans cannot proceed if quantity=0 (application logic).
+
+SET NAMES utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+
+-- Roles table
+CREATE TABLE roles (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  code VARCHAR(64) NOT NULL UNIQUE,
+  name VARCHAR(128) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Users table
+CREATE TABLE users (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  name VARCHAR(150) NOT NULL,
+  email VARCHAR(190) NOT NULL UNIQUE,
+  password_hash VARCHAR(100) NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- User roles junction table
+CREATE TABLE user_roles (
+  user_id BIGINT NOT NULL,
+  role_id BIGINT NOT NULL,
+  PRIMARY KEY (user_id, role_id),
+  CONSTRAINT fk_user_roles_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  CONSTRAINT fk_user_roles_role FOREIGN KEY (role_id) REFERENCES roles(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Books table
+CREATE TABLE books (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  isbn VARCHAR(32) NOT NULL UNIQUE,
+  title VARCHAR(255) NOT NULL,
+  author VARCHAR(255) NOT NULL,
+  genre VARCHAR(100) NULL,
+  quantity INT NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CHECK (quantity >= 0)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Loans table
+CREATE TABLE loans (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  book_id BIGINT NOT NULL,
+  user_id BIGINT NOT NULL,
+  checkout_at DATETIME NOT NULL,
+  due_at DATETIME NOT NULL,
+  returned_at DATETIME NULL,
+  status VARCHAR(32) NOT NULL,
+  CONSTRAINT fk_loans_book FOREIGN KEY (book_id) REFERENCES books(id),
+  CONSTRAINT fk_loans_user FOREIGN KEY (user_id) REFERENCES users(id)
+  -- NOTE: Renewals allowed up to 2 if no reservation exists (business rule, enforce in service layer)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Reservations table
+CREATE TABLE reservations (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  book_id BIGINT NOT NULL,
+  user_id BIGINT NOT NULL,
+  created_at DATETIME NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  position INT NOT NULL,
+  CONSTRAINT fk_reservations_book FOREIGN KEY (book_id) REFERENCES books(id),
+  CONSTRAINT fk_reservations_user FOREIGN KEY (user_id) REFERENCES users(id)
+  -- NOTE: position is assigned first-come-first-served (enforce in application logic)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Fines table
+CREATE TABLE fines (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  user_id BIGINT NOT NULL,
+  loan_id BIGINT NOT NULL,
+  amount DECIMAL(10,2) NOT NULL,
+  status VARCHAR(32) NOT NULL,
+  created_at DATETIME NOT NULL,
+  paid_at DATETIME NULL,
+  CONSTRAINT fk_fines_user FOREIGN KEY (user_id) REFERENCES users(id),
+  CONSTRAINT fk_fines_loan FOREIGN KEY (loan_id) REFERENCES loans(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- Audit log table
+CREATE TABLE audit_log (
+  id BIGINT PRIMARY KEY AUTO_INCREMENT,
+  actor_user_id BIGINT NOT NULL,
+  action VARCHAR(150) NOT NULL,
+  target_type VARCHAR(100) NOT NULL,
+  target_id BIGINT NOT NULL,
+  ts TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  metadata JSON NULL,
+  CONSTRAINT fk_audit_actor FOREIGN KEY (actor_user_id) REFERENCES users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/main/resources/db/migration/V2__indexes_views.sql
+++ b/src/main/resources/db/migration/V2__indexes_views.sql
@@ -1,0 +1,31 @@
+-- V2: Helpful indexes and reporting views (per docs scope)
+
+-- Indexes (only those specified)
+CREATE INDEX idx_books_isbn ON books(isbn);
+CREATE INDEX idx_books_title ON books(title);
+CREATE INDEX idx_books_author ON books(author);
+
+CREATE INDEX idx_loans_user_book ON loans(user_id, book_id);
+
+CREATE INDEX idx_reservations_book_created ON reservations(book_id, created_at);
+
+CREATE INDEX idx_fines_user_status ON fines(user_id, status);
+
+-- Views (placeholders for reporting)
+DROP VIEW IF EXISTS v_popular_books;
+CREATE VIEW v_popular_books AS
+SELECT
+  l.book_id,
+  COUNT(*) AS borrow_count
+FROM loans l
+GROUP BY l.book_id;
+
+DROP VIEW IF EXISTS v_overdue_loans;
+CREATE VIEW v_overdue_loans AS
+SELECT
+  l.id AS loan_id,
+  l.user_id,
+  GREATEST(DATEDIFF(NOW(), l.due_at), 0) AS days_overdue
+FROM loans l
+WHERE l.returned_at IS NULL
+  AND l.due_at < NOW();

--- a/src/main/resources/db/migration/V3__seed_minimal_roles.sql
+++ b/src/main/resources/db/migration/V3__seed_minimal_roles.sql
@@ -1,0 +1,12 @@
+-- V3: Seed baseline roles matching stakeholders (RBAC)
+INSERT INTO roles (code, name)
+VALUES
+  ('ADMIN', 'System Administrator'),
+  ('CHIEF_LIBRARIAN', 'Chief Librarian'),
+  ('LIBRARIAN', 'Librarian'),
+  ('ASSISTANT', 'Library Assistant'),
+  ('STUDENT', 'University Student'),
+  ('IT_SUPPORT', 'IT Support Officer'),
+  ('ACADEMIC_COORD', 'Academic Coordinator')
+ON DUPLICATE KEY UPDATE name = VALUES(name);
+

--- a/src/main/resources/db/migration/V4__audit_log_nullable_for_auth_events.sql
+++ b/src/main/resources/db/migration/V4__audit_log_nullable_for_auth_events.sql
@@ -1,0 +1,5 @@
+-- V4: Relax audit_log columns to allow failed login entries without a user/target
+ALTER TABLE audit_log
+  MODIFY COLUMN actor_user_id BIGINT NULL,
+  MODIFY COLUMN target_id BIGINT NULL;
+

--- a/src/main/resources/static/dashboard.html
+++ b/src/main/resources/static/dashboard.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>LMS Dashboard</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background:#f6f7fb; }
+    .wrap { max-width:900px; margin:6vh auto; background:#fff; padding:24px; border-radius:8px; box-shadow:0 2px 10px rgba(0,0,0,0.08);}
+    h1 { margin:0 0 12px; }
+    code { background:#edf2f7; padding:2px 6px; border-radius:4px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Welcome to LMS</h1>
+    <p>You're signed in. Try calling <code>/api/me</code> to view your principal (email + roles). For quick test:</p>
+    <pre>curl -b cookies.txt -c cookies.txt http://localhost:8081/api/me</pre>
+    <p><a href="/logout">Logout</a></p>
+  </div>
+</body>
+</html>
+

--- a/src/main/resources/static/login.html
+++ b/src/main/resources/static/login.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>LMS Login</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; background:#f6f7fb; }
+    .card { max-width:360px; margin:10vh auto; background:#fff; padding:24px; border-radius:8px; box-shadow:0 2px 10px rgba(0,0,0,0.08);}
+    label { display:block; margin:12px 0 6px; font-weight:600; }
+    input { width:100%; padding:10px; border:1px solid #d0d4dd; border-radius:6px; }
+    button { margin-top:16px; width:100%; padding:10px; border:0; border-radius:6px; background:#2b6cb0; color:#fff; font-weight:700; cursor:pointer; }
+    .hint { color:#4a5568; font-size:12px; margin-top:12px; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h2 style="margin:0 0 8px;">Library Management System</h2>
+    <p style="margin:0 0 16px; color:#4a5568;">Please sign in to continue</p>
+    <form method="post" action="/login">
+      <label for="email">Email</label>
+      <input id="email" name="email" type="email" placeholder="you@example.com" required />
+
+      <label for="password">Password</label>
+      <input id="password" name="password" type="password" placeholder="••••••••" required />
+
+      <button type="submit">Sign in</button>
+    </form>
+    <div class="hint">
+      Demo accounts:<br/>
+      admin@lms.local / Admin@123<br/>
+      librarian@lms.local / Librarian@123<br/>
+      student1@lms.local / Student@123
+    </div>
+  </div>
+</body>
+</html>
+

--- a/src/test/java/lk/sliit/lms/lmsbackend/LmsBackendApplicationTests.java
+++ b/src/test/java/lk/sliit/lms/lmsbackend/LmsBackendApplicationTests.java
@@ -1,8 +1,11 @@
 package lk.sliit.lms.lmsbackend;
 
+import lk.sliit.lms.audit.AuditLogRepository;
+import lk.sliit.lms.auth.RoleRepository;
+import lk.sliit.lms.auth.UserRepository;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest(
     classes = lk.sliit.lms.LmsBackendApplication.class,
@@ -11,6 +14,15 @@ import org.springframework.boot.test.context.SpringBootTest;
     }
 )
 class LmsBackendApplicationTests {
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private RoleRepository roleRepository;
+
+    @MockBean
+    private AuditLogRepository auditLogRepository;
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
Replaces in-memory users with database-backed authentication using BCrypt and role-based access control. Adds JPA repositories for users, roles, books, loans, reservations, and audit logs. Introduces Flyway migrations for schema and seed data, demo data seeder for local profile, and controllers for API endpoints. Updates configuration, environment files, and documentation to reflect new authentication and database setup.

## Title
<!-- Use Conventional Commit format: type(scope): short summary -->
<!-- Example: feat(auth): add RBAC role guards -->

## What & Why
- [ ] What changed (bullet points)
- [ ] Why this change is needed
- [ ] Related issue/task ID: #

## Test/Verification
- [ ] Build passes locally (`./mvnw clean package`)
- [ ] Tests pass (`./mvnw test`)
- [ ] Manual testing completed
- [ ] No breaking changes (or documented below)

## Screenshots (if UI)
<!-- Add before/after screenshots for visual changes -->

## Breaking Changes
<!-- List any breaking changes or mark "None" -->
None
